### PR TITLE
[FIX] removed useless supplementary date in nested comments feat

### DIFF
--- a/src/controllers/artPublication/commentController.mjs
+++ b/src/controllers/artPublication/commentController.mjs
@@ -141,7 +141,8 @@ export const getCommentsByArtPublicationId = async (req, res) => {
         const nestedComment = nestedDoc.data();
         nestedComment.isLiked = nestedComment.likes.includes(userId);
         nestedComment.id = nestedDoc.id;
-        nestedComment.createdAt = nestedComment.createdAt.toDate().toISOString();
+        // nestedComment.createdAt = nestedComment.createdAt.toDate().toISOString();
+        // just... why ?
         return nestedComment;
       });
 


### PR DESCRIPTION
useless date was added when it's already there, was merged without proper testing, resulting in crash.