### PR TITLE
[ADD] emailNotificationEnabled to false in account creation.

### DIFF
--- a/src/controllers/authentification/google.mjs
+++ b/src/controllers/authentification/google.mjs
@@ -60,6 +60,7 @@ passport.use(
                         canPostArticles: true,
                         bannerPicture: 'uploads/static/default-banner-pic.png',
                         stripeAccountId: '',
+                        emailNotificationEnabled: false,
                     };
                     user = new User(userData);
                     await newUserRef.set(user.toJSON());
@@ -164,6 +165,7 @@ export const mobileLogin = async (req, res, next) => {
                 canPostArticles: true,
                 bannerPicture: 'uploads/static/default-banner-pic.png',
                 stripeAccountId: '',
+                emailNotificationEnabled: false,
             };
             user = new User(userData);
             await newUserRef.set(user.toJSON());

--- a/src/controllers/authentification/signupController.mjs
+++ b/src/controllers/authentification/signupController.mjs
@@ -55,6 +55,7 @@ export const signup = async (req, res) => {
       profilePicture: 'uploads/static/default-profile-pic.png',
       bannerPicture: 'uploads/static/default-banner-pic.png',
       stripeAccountId: '',
+      emailNotificationEnabled: false,
     };
 
     await newUserRef.set(user);

--- a/src/routes/userRoutes.mjs
+++ b/src/routes/userRoutes.mjs
@@ -144,6 +144,9 @@ router.get("/user/check-email/:email", limiter, checkEmailAvailability);
  *                   type: string
  *                 bannerPicture:
  *                   type: string
+ *                 emailNotificationEnabled:
+ *                   type: boolean
+ *                   description: Indicates if email notifications are enabled.
  *                 socialMediaLinks:
  *                   type: object
  *                   properties:


### PR DESCRIPTION
emailNotificationEnabled key was undefined even though there is a default value in the constructor because it turns out firestore doesn't care about default values in its constructor.